### PR TITLE
Fix usage message

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -27,7 +27,7 @@ func help() {
 %s
 
 Usage:
-  %s %s
+  %s
 
 Options:
   -h, --help    Show this help message
@@ -35,7 +35,7 @@ Options:
 
 Examples:
   %s
-`, Name, Version, Desc, Name, Example, Example)
+`, Name, Version, Desc, Example, Example)
 }
 
 func ParseArgs() (*os.File, error) {


### PR DESCRIPTION
Remove a mention of `modo`:

```
Usage:
  modo modo <file>
```

becomes

```
Usage:
  modo <file>
```